### PR TITLE
Update benchmarkPlot.R

### DIFF
--- a/snakemake_wrapper/scripts/benchmarkPlot.R
+++ b/snakemake_wrapper/scripts/benchmarkPlot.R
@@ -25,7 +25,7 @@ benchmarkReports <- lapply(benchmarkFiles, function (file) {
   return(benchmarkReport)
 })
 
-fullBenchmarkReport <- rbindlist(benchmarkReports)
+fullBenchmarkReport <- rbindlist(benchmarkReports, fill = TRUE)
 
 pdf(targetPlot)
 


### PR DESCRIPTION
Changed line 28 to
fullBenchmarkReport <- rbindlist(benchmarkReports, fill = TRUE)

This helped me merge the annotated-dmrs.csv and umr-lmr-all.csv files if they have different numbers of columns.